### PR TITLE
ci: Check Pull Request Titles

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Tasks"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-pr-title:
+    name: Check Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Pull Request Title
+        uses: deepakputhraya/action-pr-title@v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to ensure that pull request titles follow a specific format. The most important change is the addition of the `pull-request-tasks.yml` file, which defines the workflow.

New GitHub Actions workflow:

* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR1-R18): Added a new workflow named "Pull Request Tasks" that triggers on pull request events (opened, edited, synchronized). This workflow includes a job to check the pull request title against a set of allowed prefixes using the `deepakputhraya/action-pr-title` action.

Fixes #14 